### PR TITLE
Fixup CI example to work with TeamCity plugin using Release Managemen…

### DIFF
--- a/gradle-examples/3/gradle-example-ci-server/build.gradle
+++ b/gradle-examples/3/gradle-example-ci-server/build.gradle
@@ -21,18 +21,54 @@ buildscript {
 }
 
 allprojects {
+  repositories {
+      jcenter() 
+  }
   apply plugin: 'java'
   apply plugin: 'maven'
 
   group = 'org.jfrog.example.gradle'
-  version = '1.0'
-  status = 'integration'
+/* use currentVersion from gradle.properties
+ *  configure CI to update this property on release build
+ *  TeamCity Relase Management Gradle Plugin example  
+ *  set both 'Release properties:' and 'Next Integration Properties'
+ *  to 'currentVersion'
+ */
+  version = currentVersion
+  // Maven style integration status 
+  if( version.endsWith("-SNAPSHOT" ) )
+    status = 'integration'
+  else
+    status = 'release'
 }
-
-// Setting this property to true will make the artifactoryPublish task
-// skip this module (in our case, the root module):
-artifactoryPublish.skip = true
+ 
+/* Setting the task 'artifactoryPublish' property 'skip to 'true'
+ * to true will make the artifactoryPublish task  skip this module 
+ * (in our case, the root module): Otherwise a jar file with a 
+ * manifest only will be published.
+ * If running standalone without the artifactory plugin applied 
+ * you cannot refernce the property directly withhout error.
+ * the task is created very late in the lifecycle so wait until
+ * the root project is evaluted then check if the artifactoryPublish
+ * task exists - only then set the task property 'skip' to "true"
+ */
+afterEvaluate  { p ->
+  Task t = p.tasks.findByPath(":artifactoryPublish") 
+  if( t != null ){
+      println "HAS artifactoryPublish task -- setting 'skip' to 'true'"
+      t.setProperty("skip","true")
+  } else {
+     // Running without artifcatory -- need a resolving repository
+     println "DOES NOT HAVE artifactoryPublish -- adding jcenter repository"
+     rootProject.allprojects {
+       repositories { 
+         jcenter() 
+       }
+    }
+  }
+}
+  
 
 task wrapper(type: Wrapper) {
-  gradleVersion = '2.4'
+  gradleVersion = '2.11' // modern version 
 }

--- a/gradle-examples/4/gradle-example-ci-server/build.gradle
+++ b/gradle-examples/4/gradle-example-ci-server/build.gradle
@@ -42,11 +42,6 @@ allprojects {
     status = 'release'
 }
  
-// Services is a war project without its own build.gradle
-project(':services') {
-  apply plugin: 'war'
-}
-
 /* Setting the task 'artifactoryPublish' property 'skip to 'true'
  * to true will make the artifactoryPublish task  skip this module 
  * (in our case, the root module): Otherwise a jar file with a 

--- a/gradle-examples/4/gradle-example-ci-server/build.gradle
+++ b/gradle-examples/4/gradle-example-ci-server/build.gradle
@@ -21,18 +21,59 @@ buildscript {
 }
 
 allprojects {
+  repositories {
+      jcenter() 
+  }
   apply plugin: 'java'
   apply plugin: 'maven'
 
   group = 'org.jfrog.example.gradle'
-  version = '1.0'
-  status = 'integration'
+/* use currentVersion from gradle.properties
+ *  configure CI to update this property on release build
+ *  TeamCity Relase Management Gradle Plugin example  
+ *  set both 'Release properties:' and 'Next Integration Properties'
+ *  to 'currentVersion'
+ */
+  version = currentVersion
+  // Maven style integration status 
+  if( version.endsWith("-SNAPSHOT" ) )
+    status = 'integration'
+  else
+    status = 'release'
+}
+ 
+// Services is a war project without its own build.gradle
+project(':services') {
+  apply plugin: 'war'
 }
 
-// Setting this property to true will make the artifactoryPublish task
-// skip this module (in our case, the root module):
-artifactoryPublish.skip = true
+/* Setting the task 'artifactoryPublish' property 'skip to 'true'
+ * to true will make the artifactoryPublish task  skip this module 
+ * (in our case, the root module): Otherwise a jar file with a 
+ * manifest only will be published.
+ * If running standalone without the artifactory plugin applied 
+ * you cannot refernce the property directly withhout error.
+ * the task is created very late in the lifecycle so wait until
+ * the root project is evaluted then check if the artifactoryPublish
+ * task exists - only then set the task property 'skip' to "true"
+ */
+afterEvaluate  { p ->
+  Task t = p.tasks.findByPath(":artifactoryPublish") 
+  if( t != null ){
+      println "HAS artifactoryPublish task -- setting 'skip' to 'true'"
+      t.setProperty("skip","true")
+  } else {
+     // Running without artifcatory -- need a resolving repository
+     println "DOES NOT HAVE artifactoryPublish -- adding jcenter repository"
+     rootProject.allprojects {
+       repositories { 
+         jcenter() 
+       }
+    }
+  }
+}
+  
 
 task wrapper(type: Wrapper) {
-  gradleVersion = '2.4'
+  gradleVersion = '2.11' // modern version 
 }


### PR DESCRIPTION
Added comments and fixed gradle build to better demonstrate CI integration with the following
- support building outside of a CI server by 
  1. Conditionally adding jcenter() depending on if the artifactoryPublish task exists
  2. Set the 'artifactoryPublish.skip' property in a mannor which doesnt cause evalutation errors if the artifactory plugin is not applied.
- Correct use of 'version' and 'currentVersion' property to demonstrate how to use the TeamCity Gradle Plugin with Release Management feature -- was hard-coded to 'version "1."' -- other examples correctly used the currentVersion property.  This is likely (not tested) to be the correct fix for other CI server integrations.
- update wrapper to gradle 2.11 ( not absolutely needed)
