### PR TITLE
Mere mortal fixes.  :)

### DIFF
--- a/gradle-examples/3/gradle-android-aar/build.gradle
+++ b/gradle-examples/3/gradle-android-aar/build.gradle
@@ -62,7 +62,7 @@ configure(install.repositories.mavenInstaller) {
     }
 
 artifactory {
-    contextUrl = 'http://localhost:8081/artifactory'
+    contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
     publish {
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/3/gradle-example-bintray-info/build.gradle
+++ b/gradle-examples/3/gradle-example-bintray-info/build.gradle
@@ -106,7 +106,7 @@ task writeNewPom(type:Exec) {
 }
 
 artifactory {
-  contextUrl = 'http://localhost:8081/artifactory'
+  contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
   publish {
     repository {
       repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/3/gradle-example-minimal/build.gradle
+++ b/gradle-examples/3/gradle-example-minimal/build.gradle
@@ -42,7 +42,7 @@ publishing {
 }
 
 artifactory {
-    contextUrl = 'http://localhost:8081/artifactory'
+    contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
     publish {
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/3/gradle-example-publish-bintray-info/build.gradle
+++ b/gradle-examples/3/gradle-example-publish-bintray-info/build.gradle
@@ -94,7 +94,7 @@ task createBintrayInfoFile(type:Exec) {
 }
 
 artifactory {
-    contextUrl = 'http://localhost:8080/artifactory'
+    contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
     publish {
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/3/gradle-example-publish/build.gradle
+++ b/gradle-examples/3/gradle-example-publish/build.gradle
@@ -99,7 +99,7 @@ artifactory {
     clientConfig.setIncludeEnvVars(true)
     clientConfig.info.addEnvironmentProperty('test.adding.dynVar',new java.util.Date().toString())
 
-    contextUrl = 'http://localhost:8081/artifactory'
+    contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
     publish {
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/3/gradle-example/build.gradle
+++ b/gradle-examples/3/gradle-example/build.gradle
@@ -73,7 +73,7 @@ configurations {
 }
 
 artifactory {
-  contextUrl = 'http://localhost:8081/artifactory'
+  contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
   publish {
     repository {
       repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/4/gradle-android-aar/build.gradle
+++ b/gradle-examples/4/gradle-android-aar/build.gradle
@@ -63,7 +63,7 @@ configure(install.repositories.mavenInstaller) {
     }
 
 artifactory {
-    contextUrl = 'http://localhost:8081/artifactory'
+    contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
     publish {
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/4/gradle-example-bintray-info/build.gradle
+++ b/gradle-examples/4/gradle-example-bintray-info/build.gradle
@@ -106,7 +106,7 @@ task writeNewPom(type:Exec) {
 }
 
 artifactory {
-  contextUrl = 'http://localhost:8081/artifactory'
+  contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
   publish {
     repository {
       repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/4/gradle-example-minimal/build.gradle
+++ b/gradle-examples/4/gradle-example-minimal/build.gradle
@@ -42,7 +42,8 @@ publishing {
 }
 
 artifactory {
-    contextUrl = 'http://localhost:8081/artifactory'
+    // not sure why findProperty can't be used with ?: operator....
+    contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
     publish {
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/4/gradle-example-publish-bintray-info/build.gradle
+++ b/gradle-examples/4/gradle-example-publish-bintray-info/build.gradle
@@ -95,7 +95,7 @@ task createBintrayInfoFile(type:Exec) {
 }
 
 artifactory {
-    contextUrl = 'http://localhost:8081/artifactory'
+    contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
     publish {
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/4/gradle-example-publish/build.gradle
+++ b/gradle-examples/4/gradle-example-publish/build.gradle
@@ -99,7 +99,7 @@ artifactory {
     clientConfig.setIncludeEnvVars(true)
     clientConfig.info.addEnvironmentProperty('test.adding.dynVar',new java.util.Date().toString())
 
-    contextUrl = 'http://localhost:8081/artifactory'
+    contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
     publish {
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/4/gradle-example/build.gradle
+++ b/gradle-examples/4/gradle-example/build.gradle
@@ -73,7 +73,7 @@ configurations {
 }
 
 artifactory {
-  contextUrl = 'http://localhost:8081/artifactory'
+  contextUrl = project.hasProperty('artifactory_url') ? project.getProperty('artifactory_url') : 'http://localhost:8081/artifactory'
   publish {
     repository {
       repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/README.md
+++ b/gradle-examples/README.md
@@ -15,3 +15,12 @@ To make it easier to configure the plugin, version 4 has removed the *com.jfrog.
 We therefore split the Gradle examples 
 into [Version 4 Examples](https://github.com/JFrogDev/project-examples/tree/master/gradle-examples/4) 
 and [Version 3 Examples](https://github.com/JFrogDev/project-examples/tree/master/gradle-examples/3).  
+
+### A note about publishing.
+These examples assume that you are running artifactory on localhost at port 8081.
+However, they have a property that allows you to point at a different artifactory URL.
+
+You can pass -Partifactory_url=http://artifactory.your.company:8081/artifactory to point at a different artifactory server.
+If you're using artifactory SAAS, the url is a little bit different, it'll be -Partifactory_url=https://example.jfrog.io/example
+Notice that the url ends with the name of your artifactory instance instead of /artifactory when using artifactory SAAS.
+


### PR DESCRIPTION
This fixes the examples allows you to push to your artifactory SAAS using the following:
 ./gradlew artifactoryPublish -Partifactory_url=https://meremortal.jfrog.io/meremortal/ -Partifactory_user=mortal-ci -Partifactory_password=my_api_key

If you get a 405, and are using artifactory saas, it's because you had https://cname/artifactory, and not https://cname/name  which in my case is meremortal.

