### PR TITLE
Changed JFrogDev project references to JFrog

### DIFF
--- a/artifactory-client-java-examples/README.md
+++ b/artifactory-client-java-examples/README.md
@@ -3,5 +3,5 @@
 The Artifactory Java Client provides a set of java APIs which you use to work with JFrog Artifactory from your java code.
 It Allows managing Artifactory repositories, users, groups, permissions and system configuration. It also allows searches, 
 upload and download artifacts to or from Artifactory and a lot more.
-The client's documentation is available [here](https://github.com/JFrogDev/artifactory-client-java).<br />
+The client's documentation is available [here](https://github.com/JFrog/artifactory-client-java).<br />
 We created a few project examples, to help you get started using the client.

--- a/build-info-java-example/README.md
+++ b/build-info-java-example/README.md
@@ -1,5 +1,5 @@
 # build-info-java-example
-This project is an example that demonstrates the ability to create an Artifactory build-info object, deploy it to Artifactory and deploy the build artifact from a filesystem directory to Artifactory by using the [build-info OSS project](https://github.com/JFrogDev/build-info), similar to what the CI/build tools Artifactory plugins do.
+This project is an example that demonstrates the ability to create an Artifactory build-info object, deploy it to Artifactory and deploy the build artifact from a filesystem directory to Artifactory by using the [build-info OSS project](https://github.com/JFrog/build-info), similar to what the CI/build tools Artifactory plugins do.
 
 
 ### Motivation
@@ -14,7 +14,7 @@ You can either run this from your IDE, or on a command line. To run it from your
 In order to run it from the command line, please follow the below instructions:  
 First, clone the code:
 ```
-git clone git@github.com:JFrogDev/project-examples.git
+git clone git@github.com:JFrog/project-examples.git
 ```
 Once you have the code on your machine, run:
 ```mvn install```

--- a/jenkins-examples/job-dsl-examples/freestyle-generic-example/JobDSL.groovy
+++ b/jenkins-examples/job-dsl-examples/freestyle-generic-example/JobDSL.groovy
@@ -9,7 +9,7 @@ def upSpec = """{
 
 job("job-dsl-artifactory-freestyle-generic-example") {
     scm {
-        git("https://github.com/JFrogDev/project-examples.git", "master")
+        git("https://github.com/JFrog/project-examples.git", "master")
     }
 
     configure { node ->

--- a/jenkins-examples/job-dsl-examples/freestyle-gradle-example/JobDSL.groovy
+++ b/jenkins-examples/job-dsl-examples/freestyle-gradle-example/JobDSL.groovy
@@ -1,6 +1,6 @@
 job("job-dsl-artifactory-freestyle-gradle-example") {
     scm {
-        git("https://github.com/JFrogDev/project-examples.git", "master")
+        git("https://github.com/JFrog/project-examples.git", "master")
     }
 
     configure { node ->

--- a/jenkins-examples/job-dsl-examples/freestyle-ivy-example/JobDSL.groovy
+++ b/jenkins-examples/job-dsl-examples/freestyle-ivy-example/JobDSL.groovy
@@ -1,6 +1,6 @@
 job("job-dsl-artifactory-freestyle-ivy-example") {
     scm {
-        git("https://github.com/JFrogDev/project-examples.git", "master")
+        git("https://github.com/JFrog/project-examples.git", "master")
     }
 
     configure { node ->

--- a/jenkins-examples/job-dsl-examples/freestyle-maven-example/JobDSL.groovy
+++ b/jenkins-examples/job-dsl-examples/freestyle-maven-example/JobDSL.groovy
@@ -1,6 +1,6 @@
 job("job-dsl-artifactory-freestyle-maven-example") {
     scm {
-        git("https://github.com/JFrogDev/project-examples.git", "master")
+        git("https://github.com/JFrog/project-examples.git", "master")
     }
 
     configure { node ->

--- a/jenkins-examples/job-dsl-examples/ivy-example/JobDSL.groovy
+++ b/jenkins-examples/job-dsl-examples/ivy-example/JobDSL.groovy
@@ -1,6 +1,6 @@
 ivyJob('job-dsl-artifactory-ivy-example') {
     scm {
-        git("https://github.com/JFrogDev/project-examples.git", "master")
+        git("https://github.com/JFrog/project-examples.git", "master")
     }
 
     // === Configure the Ivy builder ===

--- a/jenkins-examples/job-dsl-examples/maven-example/JobDSL.groovy
+++ b/jenkins-examples/job-dsl-examples/maven-example/JobDSL.groovy
@@ -1,6 +1,6 @@
 mavenJob('job-dsl-artifactory-maven-example') {
     scm {
-        git("https://github.com/JFrogDev/project-examples.git", "master")
+        git("https://github.com/JFrog/project-examples.git", "master")
     }
 
     configure { node ->

--- a/jenkins-examples/job-dsl-examples/pipeline-example/JobDSL.groovy
+++ b/jenkins-examples/job-dsl-examples/pipeline-example/JobDSL.groovy
@@ -1,5 +1,5 @@
 // Mandatory - Set the following Git repository in the Source control management section:
-// https://github.com/JFrogDev/project-examples.git
+// https://github.com/JFrog/project-examples.git
 pipelineJob('job-dsl-artifactory-pipeline-example') {
     parameters {
         stringParam('SERVER_ID', SERVER_ID, 'Enter Artifactory server ID')

--- a/jenkins-examples/pipeline-examples/README.md
+++ b/jenkins-examples/pipeline-examples/README.md
@@ -32,7 +32,7 @@ and then copy the content of the example's Jenkinsfile into the *Script* text-ar
 In your Jenkins job configuration, set the following:
 * Set *Definition* to "Pipeline script from SCM".
 * Set *SCM* to *Git*.
-* Set *Repository URL* to *https://github.com/JFrogDev/project-examples.git*
+* Set *Repository URL* to *https://github.com/JFrog/project-examples.git*
 * Set *Script Path* to the relative path to the example's Jenkinsfile. For example, for the below *props-example*, set *Script Path* to *jenkins-examples/pipeline-examples/props-example/Jenkinsfile* 
 
 ### Available Examples

--- a/jenkins-examples/pipeline-examples/aql-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/aql-example/Jenkinsfile
@@ -1,5 +1,5 @@
 node {
-    git url: 'https://github.com/jfrogdev/project-examples.git'
+    git url: 'https://github.com/JFrog/project-examples.git'
 
     // Get Artifactory server instance, defined in the Artifactory Plugin administration page.
     def server = Artifactory.server SERVER_ID

--- a/jenkins-examples/pipeline-examples/declarative-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/declarative-example/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
     stages {
         stage('Clone'){
             steps {
-                git url: 'https://github.com/jfrogdev/project-examples.git'
+                git url: 'https://github.com/JFrog/project-examples.git'
             }
         }
 

--- a/jenkins-examples/pipeline-examples/exclude-patterns-download-example/JenkinsFile
+++ b/jenkins-examples/pipeline-examples/exclude-patterns-download-example/JenkinsFile
@@ -1,5 +1,5 @@
 node {
-    git url: 'https://github.com/jfrogdev/project-examples.git'
+    git url: 'https://github.com/JFrog/project-examples.git'
 
     // Obtain an Artifactory server instance, defined in Jenkins --> Manage:
     def server = Artifactory.server SERVER_ID

--- a/jenkins-examples/pipeline-examples/exclude-patterns-upload-example/JenkinsFile
+++ b/jenkins-examples/pipeline-examples/exclude-patterns-upload-example/JenkinsFile
@@ -1,5 +1,5 @@
 node {
-    git url: 'https://github.com/jfrogdev/project-examples.git'
+    git url: 'https://github.com/JFrog/project-examples.git'
 
     // Obtain an Artifactory server instance, defined in Jenkins --> Manage:
     def server = Artifactory.server SERVER_ID

--- a/jenkins-examples/pipeline-examples/gradle-container-example/JenkinsFile
+++ b/jenkins-examples/pipeline-examples/gradle-container-example/JenkinsFile
@@ -4,7 +4,7 @@ node {
     def buildInfo = Artifactory.newBuildInfo()
 
     stage ('Clone') {
-        git url: 'https://github.com/jfrogdev/project-examples.git'
+        git url: 'https://github.com/JFrog/project-examples.git'
     }
 
     stage ('Artifactory configuration') {

--- a/jenkins-examples/pipeline-examples/gradle-deploy-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/gradle-deploy-example/Jenkinsfile
@@ -4,7 +4,7 @@ node {
     def rtGradle
     
     stage ('Clone') {
-        git url: 'https://github.com/jfrogdev/project-examples.git'
+        git url: 'https://github.com/JFrog/project-examples.git'
     }
  
     stage ('Artifactory configuration') {

--- a/jenkins-examples/pipeline-examples/gradle-example-ci-server/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/gradle-example-ci-server/Jenkinsfile
@@ -4,7 +4,7 @@ node {
     def buildInfo
 
     stage ('Clone') {
-        git url: 'https://github.com/jfrogdev/project-examples.git'
+        git url: 'https://github.com/JFrog/project-examples.git'
     }
 
     stage ('Artifactory configuration') {

--- a/jenkins-examples/pipeline-examples/gradle-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/gradle-example/Jenkinsfile
@@ -4,7 +4,7 @@ node {
     def buildInfo = Artifactory.newBuildInfo()
 
     stage ('Clone') {
-        git url: 'https://github.com/jfrogdev/project-examples.git'
+        git url: 'https://github.com/JFrog/project-examples.git'
     }
 
     stage ('Artifactory configuration') {

--- a/jenkins-examples/pipeline-examples/maven-container-example/JenkinsFile
+++ b/jenkins-examples/pipeline-examples/maven-container-example/JenkinsFile
@@ -4,7 +4,7 @@ node {
     def buildInfo
 
     stage ('Clone') {
-        git url: 'https://github.com/jfrogdev/project-examples.git'
+        git url: 'https://github.com/JFrog/project-examples.git'
     }
 
     stage ('Artifactory configuration') {

--- a/jenkins-examples/pipeline-examples/maven-deploy-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/maven-deploy-example/Jenkinsfile
@@ -4,7 +4,7 @@ node {
     def rtMaven
     
     stage ('Clone') {
-        git url: 'https://github.com/jfrogdev/project-examples.git'
+        git url: 'https://github.com/JFrog/project-examples.git'
     }
  
     stage ('Artifactory configuration') {

--- a/jenkins-examples/pipeline-examples/maven-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/maven-example/Jenkinsfile
@@ -4,7 +4,7 @@ node {
     def buildInfo
 
     stage ('Clone') {
-        git url: 'https://github.com/jfrogdev/project-examples.git'
+        git url: 'https://github.com/JFrog/project-examples.git'
     }
 
     stage ('Artifactory configuration') {

--- a/jenkins-examples/pipeline-examples/promotion-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/promotion-example/Jenkinsfile
@@ -1,6 +1,6 @@
 node {
     stage 'Build'
-    git url: 'https://github.com/jfrogdev/project-examples.git'
+    git url: 'https://github.com/JFrog/project-examples.git'
 
     // Obtain an Artifactory server instance, defined in Jenkins --> Manage:
     def server = Artifactory.server SERVER_ID

--- a/jenkins-examples/pipeline-examples/props-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/props-example/Jenkinsfile
@@ -1,5 +1,5 @@
 node {
-    git url: 'https://github.com/jfrogdev/project-examples.git'
+    git url: 'https://github.com/JFrog/project-examples.git'
 
     // Obtain an Artifactory server instance, defined in Jenkins --> Manage:
     def server = Artifactory.server SERVER_ID

--- a/jenkins-examples/pipeline-examples/props-single-file-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/props-single-file-example/Jenkinsfile
@@ -1,5 +1,5 @@
 node {
-    git url: 'https://github.com/jfrogdev/project-examples.git'
+    git url: 'https://github.com/JFrog/project-examples.git'
 
     // Obtain an Artifactory server instance, defined in Jenkins --> Manage:
     def server = Artifactory.server SERVER_ID

--- a/kubernetes-example/README.md
+++ b/kubernetes-example/README.md
@@ -18,7 +18,7 @@ Follow this to setup kubernetes cluster on GKE. [https://cloud.google.com/contai
 Follow this to setup kubernetes cluster on AKS. [https://docs.microsoft.com/en-us/azure/aks/tutorial-kubernetes-deploy-cluster](https://docs.microsoft.com/en-us/azure/aks/tutorial-kubernetes-deploy-cluster)
 
 ### Install Artifactory on kubernetes
-Here is documentation to install JFrog Artifactory on kubernetes [artifactory-docker-examples](https://github.com/JFrogDev/artifactory-docker-examples/tree/master/kubernetes)<br>
+Here is documentation to install JFrog Artifactory on kubernetes [artifactory-docker-examples](https://github.com/JFrog/artifactory-docker-examples/tree/master/kubernetes)<br>
 Here is link to official helm chart for Artifactory [https://github.com/kubernetes/charts/tree/master/stable/artifactory](https://github.com/kubernetes/charts/tree/master/stable/artifactory)
 
 <b>Note</b> If you are using [Artifactory SaaS](https://www.jfrog.com/artifactory/free-trial/#Cloud) you can skip this step. 

--- a/kubernetes-example/docker-app-chart/Chart.yaml
+++ b/kubernetes-example/docker-app-chart/Chart.yaml
@@ -13,4 +13,4 @@ sources:
 maintainers:
   - name: jainishshah17
     email: jainishs@jfrog.com
-icon: https://raw.githubusercontent.com/JFrogDev/artifactory-dcos/master/images/jfrog_med.png
+icon: https://raw.githubusercontent.com/JFrog/artifactory-dcos/master/images/jfrog_med.png

--- a/openshift-s2i-examples/cpp-conan/README.md
+++ b/openshift-s2i-examples/cpp-conan/README.md
@@ -1,7 +1,7 @@
 # How to containerize C++ applications using Conan and OpenShift S2I #
 
 ## Clone project ##
-``` git clone https://github.com/JFrogDev/project-examples.git && cd project-examples/openshift-s2i-examples/cpp-conan ```
+``` git clone https://github.com/JFrog/project-examples.git && cd project-examples/openshift-s2i-examples/cpp-conan ```
 
 ## Install source-to-image / s2i / sti ##
 Follow the [instructions](https://github.com/openshift/source-to-image#installation) to install s2i


### PR DESCRIPTION
Recently the JFrogDev github project moved to be simply JFrog - changed project references to adjust to this change. 