### PR TITLE
Fix Jenkins Maven and Gradle container examples

### DIFF
--- a/jenkins-examples/pipeline-examples/scripted-examples/gradle-container-example/JenkinsFile
+++ b/jenkins-examples/pipeline-examples/scripted-examples/gradle-container-example/JenkinsFile
@@ -9,7 +9,7 @@ node {
 
     stage ('Artifactory configuration') {
         rtGradle.tool = CONTAINER_GRADLE_TOOL // Tool name from Jenkins configuration
-        rtGradle.deployer repo:'libs-snapshot-local',  server: server
+        rtGradle.deployer repo:'libs-release-local',  server: server
         rtGradle.resolver repo:'jcenter', server: server
     }
 

--- a/maven-example/pom.xml
+++ b/maven-example/pom.xml
@@ -15,6 +15,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
1. [maven-container-example](https://github.com/jfrog/project-examples/tree/master/jenkins-examples/pipeline-examples/scripted-examples/maven-container-example)
Problem:  
```
[main] ERROR org.apache.maven.cli.MavenCli - Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project multi1: Compilation failure: Compilation failure: 
[main] ERROR org.apache.maven.cli.MavenCli - Source option 5 is no longer supported. Use 6 or later.
[main] ERROR org.apache.maven.cli.MavenCli - Target option 1.5 is no longer supported. Use 1.6 or later.
```
Resolution: Update Java source and target to 8.


2. [gradle-container-example](https://github.com/jfrog/project-examples/tree/master/jenkins-examples/pipeline-examples/scripted-examples/gradle-container-example)
Problem: 
```
The repository 'libs-snapshot-local' rejected the resolution of an artifact 'libs-snapshot-local:org/jfrog/example/gradle/gradle-example-ci-server/1.0/gradle-example-ci-server-1.0.jar' due to conflict in the snapshot release handling policy. Status code: 409
```
Resolution: Switch to `libs-release-local`.