### PR TITLE
Fix maven container example

### DIFF
--- a/jenkins-examples/pipeline-examples/scripted-examples/maven-container-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/scripted-examples/maven-container-example/Jenkinsfile
@@ -15,8 +15,8 @@ node {
     }
 
     stage ('Exec Maven') {
-        docker.image('maven').inside {
-            withEnv(['JAVA_HOME=/docker-java-home']) { // Java home of the container
+        docker.image('maven:3.6.1-jdk-8-slim').inside {
+            withEnv(['JAVA_HOME=/usr/local/openjdk-8']) { // Java home of the container
                 rtMaven.run pom: 'maven-example/pom.xml', goals: 'clean install', buildInfo: buildInfo
             }
         }

--- a/jenkins-examples/pipeline-examples/scripted-examples/maven-container-example/README.md
+++ b/jenkins-examples/pipeline-examples/scripted-examples/maven-container-example/README.md
@@ -8,10 +8,10 @@
         * Add the configured Maven tool name to the pipeline script:
             * rtMaven.tool = CONTAINER_MAVEN_TOOL
         * Add `JAVA_HOME` environment variable to the pipeline script.
-            *       withEnv(['JAVA_HOME=/docker-java-home/']) { // Java home of the container
+            *       withEnv(['JAVA_HOME=/usr/local/openjdk-8']) { // Java home of the container
                         rtMaven.run pom: 'maven-example/pom.xml', goals: 'clean install', buildInfo: buildInfo
                     }
     * Option 2: Set `JAVA_HOME` and `MAVEN_HOME` environment variables as configured in the container.
-        *     withEnv(['JAVA_HOME=/docker-java-home', 'MAVEN_HOME=/usr/share/maven']) {
+        *     withEnv(['JAVA_HOME=/usr/local/openjdk-8', 'MAVEN_HOME=/usr/share/maven']) {
                 rtMaven.run pom: 'maven-example/pom.xml', goals: 'clean install', buildInfo: buildInfo
               }


### PR DESCRIPTION
The 'maven' latest container is no longer using `/docker-java-home`.
Let's use a specific image tag.