### PR TITLE
Fix Gradle deprecation notices

### DIFF
--- a/artifactory-client-java-examples/gradle-example/build.gradle
+++ b/artifactory-client-java-examples/gradle-example/build.gradle
@@ -10,6 +10,6 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
-    compile 'org.jfrog.artifactory.client:artifactory-java-client-services:+'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
+    implementation 'org.jfrog.artifactory.client:artifactory-java-client-services:+'
 }

--- a/droneci-examples/drone-gradle/api/build.gradle
+++ b/droneci-examples/drone-gradle/api/build.gradle
@@ -3,11 +3,11 @@ configurations {
 }
 
 dependencies {
-    compile project(':shared')
-    compile module("commons-lang:commons-lang:2.4") {
+    implementation project(':shared')
+    implementation module("commons-lang:commons-lang:2.4") {
         dependency("commons-io:commons-io:1.2")
     }
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
 
 }
 

--- a/droneci-examples/drone-gradle/services/webservice/build.gradle
+++ b/droneci-examples/drone-gradle/services/webservice/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'war'
 
 dependencies {
-    compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
-    compile group: 'junit', name: 'junit', version: '4.11'
-    compile project(':api')
+    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'junit', name: 'junit', version: '4.11'
+    implementation project(':api')
 }

--- a/gitlabci-example/gitlabci-gradle-artifactory/api/build.gradle
+++ b/gitlabci-example/gitlabci-gradle-artifactory/api/build.gradle
@@ -3,11 +3,11 @@ configurations {
 }
 
 dependencies {
-    compile project(':shared')
-    compile module("commons-lang:commons-lang:2.4") {
+    implementation project(':shared')
+    implementation module("commons-lang:commons-lang:2.4") {
         dependency("commons-io:commons-io:1.2")
     }
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
 
 }
 

--- a/gitlabci-example/gitlabci-gradle-artifactory/services/webservice/build.gradle
+++ b/gitlabci-example/gitlabci-gradle-artifactory/services/webservice/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'war'
 
 dependencies {
-    compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
-    compile group: 'junit', name: 'junit', version: '4.11'
-    compile project(':api')
+    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'junit', name: 'junit', version: '4.11'
+    implementation project(':api')
 }

--- a/gradle-examples/gradle-android-example/build.gradle
+++ b/gradle-examples/gradle-android-example/build.gradle
@@ -68,7 +68,7 @@ artifactory {
     clientConfig.setIncludeEnvVars(true)
     clientConfig.info.addEnvironmentProperty('test.adding.dynVar',new Date().toString())
 
-    contextUrl = 'http://localhost:8081/artifactory'
+    contextUrl = 'http://127.0.0.1:8081/artifactory'
     publish {
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/gradle-cache-example/api/build.gradle
+++ b/gradle-examples/gradle-cache-example/api/build.gradle
@@ -3,11 +3,11 @@ configurations {
 }
 
 dependencies {
-    compile project(':shared')
-    compile module("commons-lang:commons-lang:2.4") {
+    implementation project(':shared')
+    implementation module("commons-lang:commons-lang:2.4") {
         dependency("commons-io:commons-io:1.2")
     }
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
 
 }
 

--- a/gradle-examples/gradle-cache-example/build.gradle
+++ b/gradle-examples/gradle-cache-example/build.gradle
@@ -34,7 +34,7 @@ allprojects {
   status = 'Integration'
   repositories {
     maven {
-      url "http://localhost:8081/artifactory/jcenter" // The Artifactory (preferably virtual) repository to resolve from
+      url "http://127.0.0.1:8081/artifactory/jcenter" // The Artifactory (preferably virtual) repository to resolve from
       credentials {
         username "${artifactory_user}" // Optional resolver user name (leave out to use anonymous resolution)
         password "${artifactory_password}" // The resolver password
@@ -57,7 +57,7 @@ subprojects {
       published
     }
     dependencies {
-      testCompile 'junit:junit:4.7'
+      testImplementation 'junit:junit:4.7'
     }
     task sourceJar(type: Jar) {
       from sourceSets.main.allSource

--- a/gradle-examples/gradle-cache-example/init.gradle
+++ b/gradle-examples/gradle-cache-example/init.gradle
@@ -3,9 +3,7 @@ gradle.projectsLoaded {
         buildscript {
             repositories {
 			maven{
-			//url "http://repo.jfrog.org/artifactory/gradle"
-			//url "http://localhost:8081/artifactory/gradle"
-			  url "http://localhost:8080/artifactory/gradle-snapshot-local"
+			  url "http://127.0.0.1:8080/artifactory/gradle-snapshot-local"
 			}
 			//mavenLocal()
             dependencies {

--- a/gradle-examples/gradle-cache-example/services/webservice/build.gradle
+++ b/gradle-examples/gradle-cache-example/services/webservice/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'war'
 
 dependencies {
-    compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
-    compile project(':api')
+    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation project(':api')
 }

--- a/gradle-examples/gradle-example-ci-server/api/build.gradle
+++ b/gradle-examples/gradle-example-ci-server/api/build.gradle
@@ -3,11 +3,11 @@ configurations {
 }
 
 dependencies {
-    compile project(':shared')
-    compile module("commons-lang:commons-lang:2.4") {
+    implementation project(':shared')
+    implementation module("commons-lang:commons-lang:2.4") {
         dependency("commons-io:commons-io:1.2")
     }
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
 
 }
 

--- a/gradle-examples/gradle-example-ci-server/services/webservice/build.gradle
+++ b/gradle-examples/gradle-example-ci-server/services/webservice/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'war'
 
 dependencies {
-    compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
-    compile group: 'junit', name: 'junit', version: '4.11'
-    compile project(':api')
+    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'junit', name: 'junit', version: '4.11'
+    implementation project(':api')
 }

--- a/gradle-examples/gradle-example-minimal/build.gradle
+++ b/gradle-examples/gradle-example-minimal/build.gradle
@@ -26,7 +26,7 @@ buildscript {
 allprojects {
     repositories {
         maven {
-            url "http://localhost:8081/artifactory/jcenter"
+            url "http://127.0.0.1:8081/artifactory/jcenter"
         }
     }
 }
@@ -38,7 +38,7 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 dependencies {
-    testCompile 'junit:junit:4.7'
+    testImplementation 'junit:junit:4.7'
 }
 
 publishing {
@@ -50,7 +50,7 @@ publishing {
 }
 
 artifactory {
-    contextUrl = 'http://localhost:8081/artifactory'
+    contextUrl = 'http://127.0.0.1:8081/artifactory'
     publish {
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/gradle-example-multi-repos/api/build.gradle
+++ b/gradle-examples/gradle-example-multi-repos/api/build.gradle
@@ -3,11 +3,11 @@ configurations {
 }
 
 dependencies {
-    compile project(':shared')
-    compile module("commons-lang:commons-lang:2.4") {
+    implementation project(':shared')
+    implementation module("commons-lang:commons-lang:2.4") {
         dependency("commons-io:commons-io:1.2")
     }
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
 
 }
 
@@ -16,7 +16,7 @@ compileJava.options.compilerArgs = ['-Xlint:unchecked']
 
 artifactory {
     publish {
-        contextUrl = 'http://localhost:8081/artifactory'
+        contextUrl = 'http://127.0.0.1:8081/artifactory'
         repository {
             repoKey = 'ext-snapshot-local' // The Artifactory repository key to publish to
             username = "${artifactory_user}" // The publisher user name

--- a/gradle-examples/gradle-example-multi-repos/build.gradle
+++ b/gradle-examples/gradle-example-multi-repos/build.gradle
@@ -40,7 +40,7 @@ allprojects {
     status = 'Integration'
     repositories {
         maven {
-            url "http://localhost:8081/artifactory/jcenter"
+            url "http://127.0.0.1:8081/artifactory/jcenter"
         }
     }
 }
@@ -56,7 +56,7 @@ configure(javaProjects()) {
     apply plugin: 'maven-publish'
 
     dependencies {
-        testCompile 'junit:junit:4.7'
+        testImplementation 'junit:junit:4.7'
     }
 
     publishing {
@@ -105,7 +105,7 @@ artifactory {
     clientConfig.info.addEnvironmentProperty('test.adding.dynVar',new java.util.Date().toString())
 
     publish {
-        contextUrl = 'http://localhost:8081/artifactory'
+        contextUrl = 'http://127.0.0.1:8081/artifactory'
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to
             username = "${artifactory_user}" // The publisher user name

--- a/gradle-examples/gradle-example-multi-repos/services/webservice/build.gradle
+++ b/gradle-examples/gradle-example-multi-repos/services/webservice/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'war'
 
 dependencies {
-    compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
-    compile project(':api')
+    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation project(':api')
 }

--- a/gradle-examples/gradle-example-publish/api/build.gradle
+++ b/gradle-examples/gradle-example-publish/api/build.gradle
@@ -3,11 +3,11 @@ configurations {
 }
 
 dependencies {
-    compile project(':shared')
-    compile module("commons-lang:commons-lang:2.4") {
+    implementation project(':shared')
+    implementation module("commons-lang:commons-lang:2.4") {
         dependency("commons-io:commons-io:1.2")
     }
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
 
 }
 

--- a/gradle-examples/gradle-example-publish/build.gradle
+++ b/gradle-examples/gradle-example-publish/build.gradle
@@ -40,7 +40,7 @@ allprojects {
     status = 'Integration'
     repositories {
         maven {
-            url "http://localhost:8081/artifactory/jcenter"
+            url "http://127.0.0.1:8081/artifactory/jcenter"
         }
     }
 }
@@ -56,7 +56,7 @@ configure(javaProjects()) {
     apply plugin: 'maven-publish'
 
     dependencies {
-        testCompile 'junit:junit:4.7'
+        testImplementation 'junit:junit:4.7'
     }
 
     publishing {
@@ -104,7 +104,7 @@ artifactory {
     clientConfig.setIncludeEnvVars(true)
     clientConfig.info.addEnvironmentProperty('test.adding.dynVar',new java.util.Date().toString())
 
-    contextUrl = 'http://localhost:8081/artifactory'
+    contextUrl = 'http://127.0.0.1:8081/artifactory'
     publish {
         repository {
             repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/gradle-example-publish/services/webservice/build.gradle
+++ b/gradle-examples/gradle-example-publish/services/webservice/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'war'
 
 dependencies {
-    compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
-    compile project(':api')
+    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation project(':api')
 }

--- a/gradle-examples/gradle-example/api/build.gradle
+++ b/gradle-examples/gradle-example/api/build.gradle
@@ -3,11 +3,11 @@ configurations {
 }
 
 dependencies {
-    compile project(':shared')
-    compile module("commons-lang:commons-lang:2.4") {
+    implementation project(':shared')
+    implementation module("commons-lang:commons-lang:2.4") {
         dependency("commons-io:commons-io:1.2")
     }
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
 
 }
 

--- a/gradle-examples/gradle-example/build.gradle
+++ b/gradle-examples/gradle-example/build.gradle
@@ -34,7 +34,7 @@ allprojects {
   status = 'Integration'
   repositories {
   	maven {
-        url "http://localhost:8081/artifactory/jcenter" // The Artifactory (preferably virtual) repository to resolve from
+        url "http://127.0.0.1:8081/artifactory/jcenter" // The Artifactory (preferably virtual) repository to resolve from
         credentials {
             username "${artifactory_user}"
             password "${artifactory_password}"
@@ -57,7 +57,7 @@ subprojects {
       published
     }
     dependencies {
-      testCompile 'junit:junit:4.7'
+      testImplementation 'junit:junit:4.7'
     }
     task sourceJar(type: Jar) {
       from sourceSets.main.allSource
@@ -82,7 +82,7 @@ configurations {
 }
 
 artifactory {
-  contextUrl = 'http://localhost:8081/artifactory'
+  contextUrl = 'http://127.0.0.1:8081/artifactory'
   publish {
     repository {
       repoKey = 'libs-snapshot-local' // The Artifactory repository key to publish to

--- a/gradle-examples/gradle-example/init.gradle
+++ b/gradle-examples/gradle-example/init.gradle
@@ -3,9 +3,7 @@ gradle.projectsLoaded {
         buildscript {
             repositories {
 			maven{
-			//url "http://repo.jfrog.org/artifactory/gradle"
-			//url "http://localhost:8081/artifactory/gradle"
-			  url "http://localhost:8080/artifactory/gradle-snapshot-local"
+			  url "http://127.0.0.1:8080/artifactory/gradle-snapshot-local"
 			}
 			//mavenLocal()
             dependencies {

--- a/gradle-examples/gradle-example/services/webservice/build.gradle
+++ b/gradle-examples/gradle-example/services/webservice/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'war'
 
 dependencies {
-    compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
-    compile project(':api')
+    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation project(':api')
 }

--- a/gradle-examples/gradle-jcenter-resolve/build.gradle
+++ b/gradle-examples/gradle-jcenter-resolve/build.gradle
@@ -7,5 +7,5 @@ repositories {
     jcenter()
 }
 dependencies {
-	compile(group: 'commons-lang', name: 'commons-lang', version: '2.6')
+    implementation group: 'commons-lang', name: 'commons-lang', version: '2.6'
 }

--- a/kubernetes-example/gradle-example/api/build.gradle
+++ b/kubernetes-example/gradle-example/api/build.gradle
@@ -3,12 +3,12 @@ configurations {
 }
 
 dependencies {
-    compile project(':shared')
-    compile module("commons-lang:commons-lang:2.4") {
+    implementation project(':shared')
+    implementation module("commons-lang:commons-lang:2.4") {
         dependency("commons-io:commons-io:1.2")
     }
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
-    compile group: 'commons-httpclient', name: 'commons-httpclient', version: '3.0'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'commons-httpclient', name: 'commons-httpclient', version: '3.0'
 
 }
 

--- a/kubernetes-example/gradle-example/services/webservice/build.gradle
+++ b/kubernetes-example/gradle-example/services/webservice/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'war'
 
 dependencies {
-    compile project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
-    compile group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
-    compile group: 'org.apache.struts', name: 'struts2-core', version: '2.3.14'
-    compile group: 'junit', name: 'junit', version: '4.11'
-    compile project(':api')
+    implementation project(':shared'), 'commons-collections:commons-collections:3.2@jar', 'commons-io:commons-io:1.2', 'commons-lang:commons-lang:2.4@jar'
+    implementation group: 'org.apache.wicket', name: 'wicket', version: '1.3.7'
+    implementation group: 'org.apache.struts', name: 'struts2-core', version: '2.3.14'
+    implementation group: 'junit', name: 'junit', version: '4.11'
+    implementation project(':api')
 }


### PR DESCRIPTION
Handle Gradle deprecation notices:
1. Update compile -> implementation:
> The compile configuration has been deprecated for dependency declaration
2. Update testCompile -> testImplementation
> The testCompile configuration has been deprecated for dependency declaration
3. Update localhost -> 127.0.0.1
> Switch Maven repository 'maven(http://localhost:8081/artifactory/jcenter)' to a secure protocol