### PR TITLE
Set variable to contain PASSWORD instead of PASS for security

### DIFF
--- a/gitlabci-example/gitlabci-docker-artifactory/.gitlab-ci.yml
+++ b/gitlabci-example/gitlabci-docker-artifactory/.gitlab-ci.yml
@@ -10,11 +10,11 @@ before_script:
   # Install Jfrog CLI
   - curl -fL https://getcli.jfrog.io | sh
   # Configure Artifactory instance with JFrog CLI
-  - ./jfrog rt config MyArtifactory --url $ARTIFACTORY_URL --user $ARTIFACTORY_USER --apikey $ARTIFACTORY_PASS
+  - ./jfrog rt config MyArtifactory --url $ARTIFACTORY_URL --user $ARTIFACTORY_USER --apikey $ARTIFACTORY_PASSWORD
   # Docker client info
   - docker info
   # Login to Artifactory docker registry
-  - docker login -u $ARTIFACTORY_USER -p $ARTIFACTORY_PASS $ARTIFACTORY_DOCKER_REPOSITORY
+  - docker login -u $ARTIFACTORY_USER -p $ARTIFACTORY_PASSWORD $ARTIFACTORY_DOCKER_REPOSITORY
 
 
 build:

--- a/gitlabci-example/gitlabci-docker-artifactory/README.md
+++ b/gitlabci-example/gitlabci-docker-artifactory/README.md
@@ -7,7 +7,7 @@ This sample project resolves dependencies from Artifactory and deploys the build
 Artifactory Pro / Artifactory SAAS
 
 #### Step 1:
-In the Docker project, configure the following Artifactory credentials, under CI/CD Settings > Secret variables: ARTIFACTORY_URL, ARTIFACTORY_USER, ARTIFACTORY_PASS, ARTIFACTORY_DOCKER_REPOSITORY and DOCKER_REPOSITORY_KEY.
+In the Docker project, configure the following Artifactory credentials, under CI/CD Settings > Secret variables: ARTIFACTORY_URL, ARTIFACTORY_USER, ARTIFACTORY_PASSWORD, ARTIFACTORY_DOCKER_REPOSITORY and DOCKER_REPOSITORY_KEY.
 ![screenshot](img/Screen_Shot1.png)
 
 #### Step 2:

--- a/gitlabci-example/gitlabci-gradle-artifactory/.gitlab-ci.yml
+++ b/gitlabci-example/gitlabci-gradle-artifactory/.gitlab-ci.yml
@@ -5,7 +5,7 @@ before_script:
   # Install JFrog CLI
   - curl -fL https://getcli.jfrog.io | sh
   # Configure Artifactory instance with JFrog CLI
-  - ./jfrog rt config --url=$ARTIFACTORY_URL --user=$ARTIFACTORY_USER --password=$ARTIFACTORY_PASS
+  - ./jfrog rt config --url=$ARTIFACTORY_URL --user=$ARTIFACTORY_USER --password=$ARTIFACTORY_PASSWORD
   - ./jfrog rt c show
   # Replace the repository name in the configuration.yml to the correct one.
   - sed -i 's,GRADLE_REPO_KEY,'"$GRADLE_REPO_KEY"',g' configuration.yaml

--- a/gitlabci-example/gitlabci-gradle-artifactory/README.md
+++ b/gitlabci-example/gitlabci-gradle-artifactory/README.md
@@ -6,7 +6,7 @@ This sample project resolves dependencies from Artifactory and deploys the build
 Artifactory Pro / Artifactory SAAS  
 
 #### Step 1:
-In the Gradle project, configure the following Artifactory credentials, under CI/CD Settings > Secret variables: ARTIFACTORY_URL, ARTIFACTORY_USER, ARTIFACTORY_PASS, and GRADLE_REPO_KEY.
+In the Gradle project, configure the following Artifactory credentials, under CI/CD Settings > Secret variables: ARTIFACTORY_URL, ARTIFACTORY_USER, ARTIFACTORY_PASSWORD, and GRADLE_REPO_KEY.
 ![screenshot](img/Screen_Shot1.png)
 
 #### Step 2:

--- a/gitlabci-example/gitlabci-maven-artifactory/.gitlab-ci.yml
+++ b/gitlabci-example/gitlabci-maven-artifactory/.gitlab-ci.yml
@@ -5,7 +5,7 @@ before_script:
   # Install JFrog CLI
   - curl -fL https://getcli.jfrog.io | sh
   # Configure Artifactory instance with JFrog CLI
-  - ./jfrog rt config --url=$ARTIFACTORY_URL --user=$ARTIFACTORY_USER --password=$ARTIFACTORY_PASS
+  - ./jfrog rt config --url=$ARTIFACTORY_URL --user=$ARTIFACTORY_USER --password=$ARTIFACTORY_PASSWORD
   - ./jfrog rt c show
   # Set the M2_HOME environment variable
   - export M2_HOME=/usr/share/maven

--- a/gitlabci-example/gitlabci-maven-artifactory/README.md
+++ b/gitlabci-example/gitlabci-maven-artifactory/README.md
@@ -6,7 +6,7 @@ This sample project resolves dependencies from Artifactory and deploys the build
 Artifactory Pro / Artifactory SAAS  
 
 #### Step 1:
-In the Maven project, configure the following Artifactory credentials, under CI/CD Settings > Secret variables: ARTIFACTORY_URL, ARTIFACTORY_USER, ARTIFACTORY_PASS, and MAVEN_REPO_KEY.
+In the Maven project, configure the following Artifactory credentials, under CI/CD Settings > Secret variables: ARTIFACTORY_URL, ARTIFACTORY_USER, ARTIFACTORY_PASSWORD, and MAVEN_REPO_KEY.
 ![screenshot](img/Screen_Shot1.png)
 
 #### Step 2:

--- a/gitlabci-example/gitlabci-npm-artifactory/.gitlab-ci.yml
+++ b/gitlabci-example/gitlabci-npm-artifactory/.gitlab-ci.yml
@@ -7,7 +7,7 @@ before_script:
   # Install JFrog CLI
   - curl -fL https://getcli.jfrog.io | sh
   # Configure Artifactory instance with JFrog CLI
-  - ./jfrog rt config --url=$ARTIFACTORY_URL --user=$ARTIFACTORY_USER --password=$ARTIFACTORY_PASS
+  - ./jfrog rt config --url=$ARTIFACTORY_URL --user=$ARTIFACTORY_USER --password=$ARTIFACTORY_PASSWORD
   - ./jfrog rt c show
 
 # This folder is cached between builds

--- a/gitlabci-example/gitlabci-npm-artifactory/README.md
+++ b/gitlabci-example/gitlabci-npm-artifactory/README.md
@@ -7,7 +7,7 @@ This sample project resolves dependencies from Artifactory and deploys the build
 Artifactory Pro / Artifactory SAAS version 5.5.2 and above.  
 
 #### Step 1:
-In the NPM project, configure the following Artifactory credentials, under CI/CD Settings > Secret variables: ARTIFACTORY_URL, ARTIFACTORY_USER, ARTIFACTORY_PASS, and ARTIFACTORY_NPM_REPOSITORY.
+In the NPM project, configure the following Artifactory credentials, under CI/CD Settings > Secret variables: ARTIFACTORY_URL, ARTIFACTORY_USER, ARTIFACTORY_PASSWORD, and ARTIFACTORY_NPM_REPOSITORY.
 ![screenshot](img/Screen_Shot1.png)
 
 #### Step 2:


### PR DESCRIPTION
jfrog cli does not exclude "PASS" by default, but does exclude "PASSWORD".