### PR TITLE
update gradle version to fix NoClassDefFoundError

### DIFF
--- a/gradle-examples/gradle-example-minimal/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-examples/gradle-example-minimal/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/gradle-examples/gradle-example-multi-repos/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-examples/gradle-example-multi-repos/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip

--- a/gradle-examples/gradle-example-publish/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle-examples/gradle-example-publish/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-all.zip


### PR DESCRIPTION
When I tried to build `gradle-example-minimal` I got error like this.

```
* Where:
Build file './project-examples/gradle-examples/gradle-example-minimal/build.gradle' line: 64

* What went wrong:
Failed to notify build listener.
> java.lang.NoClassDefFoundError: org/gradle/api/publish/internal/PublicationArtifactSet
```

And I found out this error is avoidable by update gradle version to 4.10/5/6
So I fixed gradle version to recent 4.*
Now I can build


*My env*
- macOS 10.14.6 (18G95)
- Java(TM) SE Runtime Environment (build 1.8.0_181-b13) 