### PR TITLE
Scripted pipeline - Append build info instead of override

### DIFF
--- a/jenkins-examples/pipeline-examples/scripted-examples/docker-push-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/scripted-examples/docker-push-example/Jenkinsfile
@@ -20,7 +20,7 @@ node {
     }
 
     stage ('Push image to Artifactory') {
-        buildInfo = rtDocker.push ARTIFACTORY_DOCKER_REGISTRY + '/hello-world:latest', 'docker-local'
+        rtDocker.push ARTIFACTORY_DOCKER_REGISTRY + '/hello-world:latest', 'docker-local', buildInfo
     }
 
     stage ('Publish build info') {

--- a/jenkins-examples/pipeline-examples/scripted-examples/gradle-example-ci-server/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/scripted-examples/gradle-example-ci-server/Jenkinsfile
@@ -1,7 +1,7 @@
 node {
     def server = Artifactory.newServer url: SERVER_URL, credentialsId: CREDENTIALS
     def rtGradle = Artifactory.newGradleBuild()
-    def buildInfo
+    def buildInfo = Artifactory.newBuildInfo()
 
     stage ('Clone') {
         git url: 'https://github.com/jfrog/project-examples.git'
@@ -14,7 +14,7 @@ node {
     }
 
     stage ('Exec Gradle') {
-        buildInfo = rtGradle.run rootDir: "gradle-examples/gradle-example-ci-server/", buildFile: 'build.gradle', tasks: 'clean artifactoryPublish'
+        rtGradle.run rootDir: "gradle-examples/gradle-example-ci-server/", buildFile: 'build.gradle', tasks: 'clean artifactoryPublish', buildInfo
     }
 
     stage ('Publish build info') {


### PR DESCRIPTION
To allow users to set build info values before the actual step, let's append the build info object instead of overriding it.

For example, setting build name and number:
```groovy
buildInfo.name = "frog"
buildInfo.number = "1"
```
will be overridden by:
```groovy
buildInfo = rtDocker.push ARTIFACTORY_DOCKER_REGISTRY + '/hello-world:latest', 'docker-local'
```