### PR TITLE
Gradle CI example - use 'maven-publish' plugin

### DIFF
--- a/gradle-examples/gradle-example-ci-server/build.gradle
+++ b/gradle-examples/gradle-example-ci-server/build.gradle
@@ -22,7 +22,7 @@ buildscript {
 
 allprojects {
   apply plugin: 'java'
-  apply plugin: 'maven'
+  apply plugin: 'maven-publish'
 
   group = 'org.jfrog.example.gradle'
   version = '1.0'


### PR DESCRIPTION
Use 'maven-publish' plugin instead of the deprecated 'maven' plugin.