### PR TITLE
Add Java version to Maven plugin example

### DIFF
--- a/artifactory-maven-plugin-example/pom.xml
+++ b/artifactory-maven-plugin-example/pom.xml
@@ -16,6 +16,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Resolves https://github.com/jfrog/artifactory-maven-plugin/issues/10

Set `maven.compiler.source` and `maven.compiler.target` to JDK 8.

In Maven 3.3.9 it is obligatory to add the Java version. 
Otherwise, the version will be 5 and the following error will be returned:

> source option 5 is no longer supported