### PR TITLE
Add Gradle wrapper

### DIFF
--- a/jenkins-examples/pipeline-examples/declarative-examples/build-scan-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/declarative-examples/build-scan-example/Jenkinsfile
@@ -18,15 +18,15 @@ pipeline {
                 rtMavenDeployer (
                     id: "MAVEN_DEPLOYER",
                     serverId: "ARTIFACTORY_SERVER",
-                    releaseRepo: "libs-release-local",
-                    snapshotRepo: "libs-snapshot-local"
+                    releaseRepo: ARTIFACTORY_LOCAL_RELEASE_REPO,
+                    snapshotRepo: ARTIFACTORY_LOCAL_SNAPSHOT_REPO
                 )
 
                 rtMavenResolver (
                     id: "MAVEN_RESOLVER",
                     serverId: "ARTIFACTORY_SERVER",
-                    releaseRepo: "libs-release",
-                    snapshotRepo: "libs-snapshot"
+                    releaseRepo: ARTIFACTORY_VIRTUAL_RELEASE_REPO,
+                    snapshotRepo: ARTIFACTORY_VIRTUAL_SNAPSHOT_REPO
                 )
             }
         }

--- a/jenkins-examples/pipeline-examples/declarative-examples/gradle-example-ci-server/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/declarative-examples/gradle-example-ci-server/Jenkinsfile
@@ -19,13 +19,13 @@ pipeline {
                 rtGradleDeployer (
                     id: "GRADLE_DEPLOYER",
                     serverId: "ARTIFACTORY_SERVER",
-                    repo: "libs-release-local",
+                    repo: ARTIFACTORY_LOCAL_RELEASE_REPO,
                 )
 
                 rtGradleResolver (
                     id: "GRADLE_RESOLVER",
                     serverId: "ARTIFACTORY_SERVER",
-                    repo: "libs-release"
+                    repo: ARTIFACTORY_VIRTUAL_RELEASE_REPO
                 )
             }
         }

--- a/jenkins-examples/pipeline-examples/declarative-examples/gradle-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/declarative-examples/gradle-example/Jenkinsfile
@@ -23,14 +23,14 @@ pipeline {
                 rtGradleDeployer (
                     id: "GRADLE_DEPLOYER",
                     serverId: "ARTIFACTORY_SERVER",
-                    repo: "libs-snapshot-local",
+                    repo: ARTIFACTORY_LOCAL_SNAPSHOT_REPO,
                     excludePatterns: ["*.war"],
                 )
 
                 rtGradleResolver (
                     id: "GRADLE_RESOLVER",
                     serverId: "ARTIFACTORY_SERVER",
-                    repo: "libs-release"
+                    repo: ARTIFACTORY_VIRTUAL_RELEASE_REPO
                 )
             }
         }
@@ -49,6 +49,7 @@ pipeline {
             steps {
                 rtGradleRun (
                     usesPlugin: true, // Artifactory plugin already defined in build script
+                    useWrapper: true,
                     tool: GRADLE_TOOL, // Tool name from Jenkins configuration
                     rootDir: "gradle-examples/gradle-example/",
                     buildFile: 'build.gradle',

--- a/jenkins-examples/pipeline-examples/declarative-examples/maven-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/declarative-examples/maven-example/Jenkinsfile
@@ -18,15 +18,15 @@ pipeline {
                 rtMavenDeployer (
                     id: "MAVEN_DEPLOYER",
                     serverId: "ARTIFACTORY_SERVER",
-                    releaseRepo: "libs-release-local",
-                    snapshotRepo: "libs-snapshot-local"
+                    releaseRepo: ARTIFACTORY_LOCAL_RELEASE_REPO,
+                    snapshotRepo: ARTIFACTORY_LOCAL_SNAPSHOT_REPO
                 )
 
                 rtMavenResolver (
                     id: "MAVEN_RESOLVER",
                     serverId: "ARTIFACTORY_SERVER",
-                    releaseRepo: "libs-release",
-                    snapshotRepo: "libs-snapshot"
+                    releaseRepo: ARTIFACTORY_VIRTUAL_RELEASE_REPO,
+                    snapshotRepo: ARTIFACTORY_VIRTUAL_SNAPSHOT_REPO
                 )
             }
         }

--- a/jenkins-examples/pipeline-examples/scripted-examples/gradle-container-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/scripted-examples/gradle-container-example/Jenkinsfile
@@ -14,7 +14,7 @@ node {
         rtGradle = Artifactory.newGradleBuild()
         rtGradle.tool = CONTAINER_GRADLE_TOOL // Tool name from Jenkins configuration
         rtGradle.deployer repo:ARTIFACTORY_LOCAL_RELEASE_REPO,  server: server
-        rtGradle.resolver repo:'libs-release', server: server
+        rtGradle.resolver repo:ARTIFACTORY_VIRTUAL_RELEASE_REPO, server: server
     }
 
     stage ('Exec Gradle') {

--- a/jenkins-examples/pipeline-examples/scripted-examples/gradle-example-ci-server/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/scripted-examples/gradle-example-ci-server/Jenkinsfile
@@ -13,7 +13,7 @@ node {
 
         rtGradle.tool = GRADLE_TOOL // Tool name from Jenkins configuration
         rtGradle.deployer repo: ARTIFACTORY_LOCAL_RELEASE_REPO, server: server
-        rtGradle.resolver repo: 'libs-release', server: server
+        rtGradle.resolver repo: ARTIFACTORY_VIRTUAL_RELEASE_REPO, server: server
     }
 
     stage ('Exec Gradle') {

--- a/jenkins-examples/pipeline-examples/scripted-examples/gradle-example/Jenkinsfile
+++ b/jenkins-examples/pipeline-examples/scripted-examples/gradle-example/Jenkinsfile
@@ -13,7 +13,7 @@ node {
 
         rtGradle.tool = GRADLE_TOOL // Tool name from Jenkins configuration
         rtGradle.deployer repo: ARTIFACTORY_LOCAL_SNAPSHOT_REPO, server: server
-        rtGradle.resolver repo: 'libs-release', server: server
+        rtGradle.resolver repo: ARTIFACTORY_VIRTUAL_RELEASE_REPO, server: server
     }
 
     withEnv (['DONT_COLLECT=FOO']) {
@@ -26,6 +26,7 @@ node {
         stage ('Extra gradle configurations') {
             rtGradle.deployer.artifactDeploymentPatterns.addExclude ("*.war")
             rtGradle.usesPlugin = true // Artifactory plugin already defined in build script
+            rtGradle.useWrapper = true
         }
 
         stage ('Exec Gradle') {

--- a/kubernetes-example/gradle-example/Jenkinsfile
+++ b/kubernetes-example/gradle-example/Jenkinsfile
@@ -6,11 +6,11 @@ node {
     stage 'Build'
         git url: 'https://github.com/jfrogtraining/kubernetes_example.git', branch: 'master'
 
-    //Configure Artifactroy repository to pull/push artifacts
+    //Configure Artifactory repository to pull/push artifacts
     stage 'Artifactory configuration'
         rtGradle.tool = GRADLE_TOOL // Tool name from Jenkins configuration
         rtGradle.deployer repo:DEPLOY_REPO, server: server
-        rtGradle.resolver repo:'libs-release', server: server
+        rtGradle.resolver repo:ARTIFACTORY_VIRTUAL_RELEASE_REPO, server: server
         rtGradle.deployer.addProperty("unit-test", "pass").addProperty("qa-team", "platform", "ui")
         def buildInfo = Artifactory.newBuildInfo()
         buildInfo.env.capture = true


### PR DESCRIPTION
The Gradle examples that use the Artifactory plugin are failing with Gradle 7+.
Add useWrapper to insure success.