### PR TITLE
Adapt to latest changes in Java client examples

### DIFF
--- a/artifactory-client-java-examples/gradle-example/build.gradle
+++ b/artifactory-client-java-examples/gradle-example/build.gradle
@@ -12,4 +12,6 @@ repositories {
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     implementation 'org.jfrog.artifactory.client:artifactory-java-client-services:+'
+    implementation 'org.apache.commons:commons-lang3:3.12.0'
+    implementation 'commons-io:commons-io:2.11.0'
 }

--- a/artifactory-client-java-examples/maven-example/pom.xml
+++ b/artifactory-client-java-examples/maven-example/pom.xml
@@ -20,6 +20,16 @@
             <artifactId>artifactory-java-client-services</artifactId>
             <version>RELEASE</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.11.0</version>
+        </dependency>
     </dependencies>
 
 </project>


### PR DESCRIPTION
Since 2.11.0 the Java client dependencies are no longer have the "compile" scope.
Therefore we should add them explicitly.