### PR TITLE
Maven update maven-war-plugin and add test case

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: All Tests
+on:
+  push:
+  schedule:
+    - cron: 0 0 1 * *
+jobs:
+  test_maven:
+    strategy:
+      max-parallel: 3
+      matrix:
+        image:
+          - eclipse-temurin:8-jdk
+          - adoptopenjdk/openjdk11:jdk-11.0.11_9-debian
+          - adoptopenjdk/openjdk16:jdk-16.0.1_9-debian
+          - eclipse-temurin:20-jdk
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Detect changed files
+        id: changed-files-yaml
+        uses: tj-actions/changed-files@v45
+        with:
+          files_yaml: |
+            maven:
+              - 'maven-examples/**'
+              - '.github/workflows/test.yml'
+      - name: Define options
+        run: |
+          set -x
+          if [ -n "${JOB_CONTAINER_NAME}" ]; then
+            echo "options=--volumes-from=${JOB_CONTAINER_NAME}" >> $GITHUB_ENV
+          else
+            echo "options=-v ${GITHUB_WORKSPACE}:${GITHUB_WORKSPACE}" >> $GITHUB_ENV
+          fi
+        shell: bash
+        id: define-options
+      - name: Test Maven project updates
+        uses: addnab/docker-run-action@v3
+        if: github.event.schedule == '0 0 1 * *' || steps.changed-files-yaml.outputs.maven_any_changed == 'true'
+        with:
+          image: ${{ matrix.image }}
+          options: ${{ env.options || steps.define-options.outputs.options }} --rm
+          run: |
+            cd ${{ github.workspace }}/maven-examples/maven-example
+            ./mvnw clean package

--- a/maven-examples/README.md
+++ b/maven-examples/README.md
@@ -1,0 +1,17 @@
+# Maven Examples
+
+## Prerequisites
+
+Ensure the JDK is installed locally.
+
+Apt example:
+```sh
+sudo apt install openjdk-21-jdk-headless
+```
+
+## Running Locally
+
+```sh
+cd ./maven-example
+./mvnw package
+```

--- a/maven-examples/maven-example/pom.xml
+++ b/maven-examples/maven-example/pom.xml
@@ -40,7 +40,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-war-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>3.4.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
The `maven-war-plugin` is outdated and will not build on latest JDK versions. This fixes that.

I have added the fix and a test case.

Here are the outcomes of the action runs:

1. [With just the test, without the fix](https://github.com/acrois/project-examples/actions/runs/10608430049), the test failed.
2. [With the fix](https://github.com/acrois/project-examples/actions/runs/10608430035), the test passed.

[Here is a branch with just the fix and no test](https://github.com/acrois/project-examples/tree/maven-upgrade-war-plugin).